### PR TITLE
Add Flutter frontend skeleton

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,10 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+.pub/
+build/
+flutter_*.png
+# Visual Studio Code
+.vscode/
+# Mac and Linux
+*.iml

--- a/frontend/lib/api/missions_api.dart
+++ b/frontend/lib/api/missions_api.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+import '../models/mission_dto.dart';
+
+class MissionsApi {
+  final String baseUrl;
+  final http.Client _client;
+
+  MissionsApi({required this.baseUrl, http.Client? client})
+      : _client = client ?? http.Client();
+
+  Future<List<MissionDto>> getMissions() async {
+    final response = await _client.get(Uri.parse('$baseUrl/api/missions'));
+    if (response.statusCode == 200) {
+      final data = json.decode(response.body) as List<dynamic>;
+      return data.map((e) => MissionDto.fromJson(e)).toList();
+    }
+    throw Exception('Failed to load missions');
+  }
+
+  Future<MissionDto> createMission(MissionDto mission) async {
+    final response = await _client.post(
+      Uri.parse('$baseUrl/api/missions'),
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode(mission.toJson()),
+    );
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      return MissionDto.fromJson(json.decode(response.body));
+    }
+    throw Exception('Failed to create mission');
+  }
+
+  Future<MissionDto> updateMission(MissionDto mission) async {
+    final response = await _client.put(
+      Uri.parse('$baseUrl/api/missions'),
+      headers: {'Content-Type': 'application/json'},
+      body: json.encode(mission.toJson()),
+    );
+    if (response.statusCode == 200) {
+      return MissionDto.fromJson(json.decode(response.body));
+    }
+    throw Exception('Failed to update mission');
+  }
+
+  Future<void> deleteMission(String id) async {
+    final response = await _client.delete(Uri.parse('$baseUrl/api/missions/$id'));
+    if (response.statusCode != 200) {
+      throw Exception('Failed to delete mission');
+    }
+  }
+}

--- a/frontend/lib/app_theme.dart
+++ b/frontend/lib/app_theme.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+ThemeData buildTheme() {
+  return ThemeData(
+    colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
+    useMaterial3: true,
+  );
+}

--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_redux/flutter_redux.dart';
+import 'package:redux/redux.dart';
+
+import 'redux/app_state.dart';
+import 'redux/reducers.dart';
+import 'redux/middleware.dart';
+import 'screens/missions_list.dart';
+import 'app_theme.dart';
+
+void main() {
+  final store = Store<AppState>(
+    appReducer,
+    initialState: AppState.initial(),
+    middleware: createMiddleware(),
+  );
+
+  runApp(AfttApp(store: store));
+}
+
+class AfttApp extends StatelessWidget {
+  final Store<AppState> store;
+
+  const AfttApp({Key? key, required this.store}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return StoreProvider<AppState>(
+      store: store,
+      child: MaterialApp(
+        title: 'AFTT',
+        theme: buildTheme(),
+        home: const MissionsListScreen(),
+      ),
+    );
+  }
+}

--- a/frontend/lib/models/mission_dto.dart
+++ b/frontend/lib/models/mission_dto.dart
@@ -1,0 +1,31 @@
+class MissionDto {
+  final String missionGuid;
+  final String title;
+  final String? description;
+  final String status;
+  final int urgency;
+
+  MissionDto({
+    required this.missionGuid,
+    required this.title,
+    this.description,
+    required this.status,
+    required this.urgency,
+  });
+
+  factory MissionDto.fromJson(Map<String, dynamic> json) => MissionDto(
+        missionGuid: json['missionGuid'] as String,
+        title: json['title'] as String,
+        description: json['description'] as String?,
+        status: json['status'] as String,
+        urgency: json['urgency'] as int,
+      );
+
+  Map<String, dynamic> toJson() => {
+        'missionGuid': missionGuid,
+        'title': title,
+        'description': description,
+        'status': status,
+        'urgency': urgency,
+      };
+}

--- a/frontend/lib/redux/actions.dart
+++ b/frontend/lib/redux/actions.dart
@@ -1,0 +1,20 @@
+import '../models/mission_dto.dart';
+
+class LoadMissions {}
+class MissionsLoaded {
+  final List<MissionDto> missions;
+  MissionsLoaded(this.missions);
+}
+class MissionsLoadFailed { final String error; MissionsLoadFailed(this.error); }
+
+class CreateMission { final MissionDto mission; CreateMission(this.mission); }
+class MissionCreated { final MissionDto mission; MissionCreated(this.mission); }
+class MissionCreateFailed { final String error; MissionCreateFailed(this.error); }
+
+class UpdateMission { final MissionDto mission; UpdateMission(this.mission); }
+class MissionUpdated { final MissionDto mission; MissionUpdated(this.mission); }
+class MissionUpdateFailed { final String error; MissionUpdateFailed(this.error); }
+
+class DeleteMission { final String id; DeleteMission(this.id); }
+class MissionDeleted { final String id; MissionDeleted(this.id); }
+class MissionDeleteFailed { final String error; MissionDeleteFailed(this.error); }

--- a/frontend/lib/redux/app_state.dart
+++ b/frontend/lib/redux/app_state.dart
@@ -1,0 +1,19 @@
+import '../models/mission_dto.dart';
+
+class AppState {
+  final List<MissionDto> missions;
+  final bool isLoading;
+  final String? error;
+
+  AppState({required this.missions, required this.isLoading, this.error});
+
+  factory AppState.initial() => AppState(missions: [], isLoading: false);
+
+  AppState copyWith({List<MissionDto>? missions, bool? isLoading, String? error}) {
+    return AppState(
+      missions: missions ?? this.missions,
+      isLoading: isLoading ?? this.isLoading,
+      error: error,
+    );
+  }
+}

--- a/frontend/lib/redux/middleware.dart
+++ b/frontend/lib/redux/middleware.dart
@@ -1,0 +1,69 @@
+import 'package:redux/redux.dart';
+import '../api/missions_api.dart';
+import 'actions.dart';
+import 'app_state.dart';
+
+List<Middleware<AppState>> createMiddleware({MissionsApi? api}) {
+  final missionsApi = api ?? MissionsApi(baseUrl: 'http://localhost:5000');
+
+  return [
+    TypedMiddleware<AppState, LoadMissions>(_loadMissions(missionsApi)),
+    TypedMiddleware<AppState, CreateMission>(_createMission(missionsApi)),
+    TypedMiddleware<AppState, UpdateMission>(_updateMission(missionsApi)),
+    TypedMiddleware<AppState, DeleteMission>(_deleteMission(missionsApi)),
+  ];
+}
+
+Middleware<AppState> _loadMissions(MissionsApi api) {
+  return (Store<AppState> store, dynamic action, NextDispatcher next) async {
+    next(action);
+    try {
+      final missions = await api.getMissions();
+      store.dispatch(MissionsLoaded(missions));
+    } catch (e) {
+      store.dispatch(MissionsLoadFailed(e.toString()));
+    }
+  };
+}
+
+Middleware<AppState> _createMission(MissionsApi api) {
+  return (Store<AppState> store, dynamic action, NextDispatcher next) async {
+    next(action);
+    if (action is CreateMission) {
+      try {
+        final created = await api.createMission(action.mission);
+        store.dispatch(MissionCreated(created));
+      } catch (e) {
+        store.dispatch(MissionCreateFailed(e.toString()));
+      }
+    }
+  };
+}
+
+Middleware<AppState> _updateMission(MissionsApi api) {
+  return (Store<AppState> store, dynamic action, NextDispatcher next) async {
+    next(action);
+    if (action is UpdateMission) {
+      try {
+        final updated = await api.updateMission(action.mission);
+        store.dispatch(MissionUpdated(updated));
+      } catch (e) {
+        store.dispatch(MissionUpdateFailed(e.toString()));
+      }
+    }
+  };
+}
+
+Middleware<AppState> _deleteMission(MissionsApi api) {
+  return (Store<AppState> store, dynamic action, NextDispatcher next) async {
+    next(action);
+    if (action is DeleteMission) {
+      try {
+        await api.deleteMission(action.id);
+        store.dispatch(MissionDeleted(action.id));
+      } catch (e) {
+        store.dispatch(MissionDeleteFailed(e.toString()));
+      }
+    }
+  };
+}

--- a/frontend/lib/redux/reducers.dart
+++ b/frontend/lib/redux/reducers.dart
@@ -1,0 +1,48 @@
+import 'package:redux/redux.dart';
+
+import "../models/mission_dto.dart";
+import 'app_state.dart';
+import 'actions.dart';
+
+AppState appReducer(AppState state, dynamic action) => AppState(
+      missions: missionsReducer(state.missions, action),
+      isLoading: loadingReducer(state.isLoading, action),
+      error: errorReducer(state.error, action),
+    );
+
+final missionsReducer = combineReducers<List<MissionDto>>([
+  TypedReducer<List<MissionDto>, MissionsLoaded>((state, action) => action.missions),
+  TypedReducer<List<MissionDto>, MissionCreated>((state, action) => [...state, action.mission]),
+  TypedReducer<List<MissionDto>, MissionUpdated>((state, action) =>
+      state.map((m) => m.missionGuid == action.mission.missionGuid ? action.mission : m).toList()),
+  TypedReducer<List<MissionDto>, MissionDeleted>((state, action) =>
+      state.where((m) => m.missionGuid != action.id).toList()),
+]);
+
+final loadingReducer = combineReducers<bool>([
+  TypedReducer<bool, LoadMissions>((state, action) => true),
+  TypedReducer<bool, MissionsLoaded>((state, action) => false),
+  TypedReducer<bool, MissionsLoadFailed>((state, action) => false),
+  TypedReducer<bool, CreateMission>((state, action) => true),
+  TypedReducer<bool, MissionCreated>((state, action) => false),
+  TypedReducer<bool, MissionCreateFailed>((state, action) => false),
+  TypedReducer<bool, UpdateMission>((state, action) => true),
+  TypedReducer<bool, MissionUpdated>((state, action) => false),
+  TypedReducer<bool, MissionUpdateFailed>((state, action) => false),
+  TypedReducer<bool, DeleteMission>((state, action) => true),
+  TypedReducer<bool, MissionDeleted>((state, action) => false),
+  TypedReducer<bool, MissionDeleteFailed>((state, action) => false),
+]);
+
+String? errorReducer(String? state, dynamic action) {
+  if (action is MissionsLoadFailed ||
+      action is MissionCreateFailed ||
+      action is MissionUpdateFailed ||
+      action is MissionDeleteFailed) {
+    return action.error;
+  }
+  if (action is LoadMissions || action is CreateMission || action is UpdateMission || action is DeleteMission) {
+    return null;
+  }
+  return state;
+}

--- a/frontend/lib/screens/mission_form.dart
+++ b/frontend/lib/screens/mission_form.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_redux/flutter_redux.dart';
+import 'package:uuid/uuid.dart';
+
+import '../models/mission_dto.dart';
+import '../redux/actions.dart';
+import '../redux/app_state.dart';
+
+class MissionFormScreen extends StatefulWidget {
+  final MissionDto? mission;
+
+  const MissionFormScreen({Key? key, this.mission}) : super(key: key);
+
+  @override
+  State<MissionFormScreen> createState() => _MissionFormScreenState();
+}
+
+class _MissionFormScreenState extends State<MissionFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late String _title;
+  late String _description;
+  late int _urgency;
+
+  @override
+  void initState() {
+    super.initState();
+    _title = widget.mission?.title ?? '';
+    _description = widget.mission?.description ?? '';
+    _urgency = widget.mission?.urgency ?? 1;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.mission == null ? 'Create Mission' : 'Edit Mission')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                initialValue: _title,
+                decoration: const InputDecoration(labelText: 'Title'),
+                onSaved: (value) => _title = value ?? '',
+                validator: (value) => value == null || value.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                initialValue: _description,
+                decoration: const InputDecoration(labelText: 'Description'),
+                onSaved: (value) => _description = value ?? '',
+              ),
+              DropdownButtonFormField<int>(
+                value: _urgency,
+                decoration: const InputDecoration(labelText: 'Urgency'),
+                onChanged: (value) => setState(() => _urgency = value ?? 1),
+                items: List.generate(5, (i) => i + 1)
+                    .map((level) => DropdownMenuItem(value: level, child: Text(level.toString())))
+                    .toList(),
+              ),
+              const SizedBox(height: 16),
+              StoreConnector<AppState, VoidCallback>(
+                converter: (store) {
+                  return () {
+                    if (_formKey.currentState!.validate()) {
+                      _formKey.currentState!.save();
+                      final mission = MissionDto(
+                        missionGuid: widget.mission?.missionGuid ?? const Uuid().v4(),
+                        title: _title,
+                        description: _description,
+                        status: widget.mission?.status ?? 'Todo',
+                        urgency: _urgency,
+                      );
+                      if (widget.mission == null) {
+                        store.dispatch(CreateMission(mission));
+                      } else {
+                        store.dispatch(UpdateMission(mission));
+                      }
+                      Navigator.pop(context);
+                    }
+                  };
+                },
+                builder: (context, callback) {
+                  return ElevatedButton(
+                    onPressed: callback,
+                    child: const Text('Save'),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/missions_list.dart
+++ b/frontend/lib/screens/missions_list.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import "package:redux/redux.dart";
+import 'package:flutter_redux/flutter_redux.dart';
+import '../redux/actions.dart';
+import '../redux/app_state.dart';
+import '../widgets/mission_card.dart';
+import 'mission_form.dart';
+
+class MissionsListScreen extends StatelessWidget {
+  const MissionsListScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return StoreConnector<AppState, _ViewModel>(
+      onInit: (store) => store.dispatch(LoadMissions()),
+      converter: (store) => _ViewModel.fromStore(store),
+      builder: (context, vm) {
+        return Scaffold(
+          appBar: AppBar(title: const Text('Missions')),
+          body: vm.isLoading
+              ? const Center(child: CircularProgressIndicator())
+              : ListView(
+                  children: vm.missions
+                      .map((m) => MissionCard(mission: m, onTap: () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) => MissionFormScreen(mission: m),
+                              ),
+                            );
+                          }))
+                      .toList(),
+                ),
+          floatingActionButton: FloatingActionButton(
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (_) => const MissionFormScreen(),
+              ),
+            ),
+            child: const Icon(Icons.add),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ViewModel {
+  final List missions;
+  final bool isLoading;
+  final Function(String) onDelete;
+
+  _ViewModel({required this.missions, required this.isLoading, required this.onDelete});
+
+  static _ViewModel fromStore(Store<AppState> store) {
+    return _ViewModel(
+      missions: store.state.missions,
+      isLoading: store.state.isLoading,
+      onDelete: (id) => store.dispatch(DeleteMission(id)),
+    );
+  }
+}

--- a/frontend/lib/widgets/mission_card.dart
+++ b/frontend/lib/widgets/mission_card.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import '../models/mission_dto.dart';
+
+class MissionCard extends StatelessWidget {
+  final MissionDto mission;
+  final VoidCallback? onTap;
+
+  const MissionCard({Key? key, required this.mission, this.onTap}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: ListTile(
+        title: Text(mission.title),
+        subtitle: Text(mission.description ?? ''),
+        trailing: Text(mission.status),
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -1,0 +1,21 @@
+name: aftt_frontend
+publish_to: 'none'
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.4
+  redux: ^5.0.0
+  flutter_redux: ^0.10.0
+  uuid: ^3.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- create a new `frontend` directory for a Flutter application
- set up Redux state management and HTTP API integration
- add basic UI screens and widgets with Material 3 theming

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eb2d15d688327b1d59ddeebd81c5c